### PR TITLE
double cast latlong

### DIFF
--- a/lib/model.dart
+++ b/lib/model.dart
@@ -12,8 +12,8 @@ class Coordinates {
 
   /// Creates coordinates from a map containing its properties.
   Coordinates.fromMap(Map map)
-      : this.latitude = map["latitude"],
-        this.longitude = map["longitude"];
+      : this.latitude = map["latitude"].toDouble(),
+        this.longitude = map["longitude"].toDouble();
 
   /// Creates a map from the coordinates properties.
   Map toMap() => {

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -12,8 +12,8 @@ class Coordinates {
 
   /// Creates coordinates from a map containing its properties.
   Coordinates.fromMap(Map map)
-      : this.latitude = map["latitude"].toDouble(),
-        this.longitude = map["longitude"].toDouble();
+      : this.latitude = map["latitude"]?.toDouble(),
+        this.longitude = map["longitude"]?.toDouble();
 
   /// Creates a map from the coordinates properties.
   Map toMap() => {


### PR DESCRIPTION
casting issue with android devices. latitude and longitude weren't being parsed in the map correctly. believe this is the fix.